### PR TITLE
types: some props with default value should be optional

### DIFF
--- a/src/components/ThemeSwitch/src/ThemeSwitch.vue
+++ b/src/components/ThemeSwitch/src/ThemeSwitch.vue
@@ -2,7 +2,7 @@
   import { useSettingStore } from '@/store/modules/setting'
 
   const props = withDefaults(defineProps<{
-    type: 'base' | 'switch'
+    type?: 'base' | 'switch'
   }>(), {
     type: 'base'
   })

--- a/src/layouts/admin/sider/components/Menu.vue
+++ b/src/layouts/admin/sider/components/Menu.vue
@@ -3,7 +3,7 @@
   import { useSettingStore } from '@/store/modules/setting'
 
   const props = withDefaults(defineProps<{
-    mode: MenuLayout
+    mode?: MenuLayout
   }>(), {
     mode: MenuLayout.VERTICAL
   })


### PR DESCRIPTION
To remove the console wran that some prop is required
The props that defined with `withDefaults` should be optional by default:
* `mode` prop of Menu component
* `type` prop of ThemeSwitch component
