### PR TITLE
feat: 基础的开发环境 Mock server

### DIFF
--- a/.eslintrc-auto-import.json
+++ b/.eslintrc-auto-import.json
@@ -1,7 +1,6 @@
 {
   "globals": {
     "EffectScope": true,
-    "ElNotification": true,
     "computed": true,
     "createApp": true,
     "customRef": true,

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 .DS_Store
 dist
+.history
 
 # local env files
 .env.local

--- a/build/vite/plugins/index.ts
+++ b/build/vite/plugins/index.ts
@@ -1,14 +1,15 @@
-import type { Plugin } from 'vite'
+import type { Plugin, PluginOption } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import legacy from '@vitejs/plugin-legacy'
 import vueSetupExtend from 'vite-plugin-vue-setup-extend'
 import { configUnocss } from './unocss'
 import { configAutoImportPlugins } from './auto-imports'
+import mockPlugin from './mock'
 
 export const createVitePlugins = (viteEnv: ViteEnv, isBuild: boolean) => {
-  const { VITE_USE_LEGACY } = viteEnv
+  const { VITE_USE_LEGACY, VITE_USE_MOCK } = viteEnv
 
-  const vitePlugins: Plugin[] = [
+  const vitePlugins: PluginOption = [
     vue({
       reactivityTransform: true
     }),
@@ -22,6 +23,10 @@ export const createVitePlugins = (viteEnv: ViteEnv, isBuild: boolean) => {
     // element-plus 自动导入
     ...configAutoImportPlugins()
   ]
+
+  if(VITE_USE_MOCK) {
+    vitePlugins.push(mockPlugin())
+  }
 
   if (isBuild) {
     // 生产环境兼容不支持ESM浏览器以及内置babel

--- a/build/vite/plugins/mock.ts
+++ b/build/vite/plugins/mock.ts
@@ -27,11 +27,11 @@ const mockPlugin: (options?: MockOptions) => PluginOption = ({
 }
 
 const mockMiddleware: Connect.NextHandleFunction = function (req, res, next) {
+  // 接受的 MOCK 请求的 HTTP 方法列表
   const acceptMethods = ['POST', 'GET']
 
   const url = req.url?.split('?')[0] ?? ''
 
-  // 只接受 POST 请求
   if(req.method && !acceptMethods.includes(req.method)) {
     next()
     return

--- a/build/vite/plugins/mock.ts
+++ b/build/vite/plugins/mock.ts
@@ -1,0 +1,57 @@
+import type { PluginOption, Connect } from 'vite'
+// @ts-ignore
+import Mock from 'mockjs'
+import mockTemplates from '../../../mock'
+
+interface MockOptions {
+  base?: string
+}
+
+const MOCK_DEFAULT_BASE = '/mock'
+
+const mockPlugin: (options?: MockOptions) => PluginOption = ({
+  base = MOCK_DEFAULT_BASE
+} = {
+  base: MOCK_DEFAULT_BASE
+}) => {
+
+  return {
+    name: '@vue-power-admin/vite-plugin-mock',
+    configureServer(server) {
+
+      return () => {
+        server.middlewares.use(base, mockMiddleware)
+      }
+    }
+  }
+}
+
+const mockMiddleware: Connect.NextHandleFunction = function (req, res, next) {
+  const acceptMethods = ['POST', 'GET']
+
+  const url = req.url?.split('?')[0] ?? ''
+
+  // 只接受 POST 请求
+  if(req.method && !acceptMethods.includes(req.method)) {
+    next()
+    return
+  }
+
+  const mockTemplate = mockTemplates[url]
+
+  // 请求的路由不在 mock 的配置路由中，不做任何处理
+  if(!mockTemplate) {
+    next()
+    return
+  }
+
+  res.writeHead(200, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify({
+    code: 0,
+    data: Mock.mock(mockTemplate),
+    message: 'mock response success'
+  }))
+
+}
+
+export default mockPlugin

--- a/mock/index.ts
+++ b/mock/index.ts
@@ -1,0 +1,14 @@
+export default {
+  '/sysadmin/user/list':  {
+    'list|10': [{
+      'id|+1': 1,
+      'username': '@first @last',
+      'name': '@cname',
+      'gender': '@pick(["男", "女"])',
+      'mobile': /1[1-9]{2}\d{8}/,
+      'roles': '@pick(["用户", "管理员"])',
+      'deptName': '@cword(3,5)部',
+      'posts': '@cword(3,5)'
+    }]
+  }
+} as any

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-vue": "^9.6.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
+    "mockjs": "^1.1.0",
     "sass": "^1.55.0",
     "terser": "^5.16.1",
     "typescript": "^4.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,7 @@ specifiers:
   js-cookie: ^3.0.1
   lint-staged: ^13.0.3
   lodash-es: ^4.17.21
+  mockjs: ^1.1.0
   nprogress: ^0.2.0
   pinia: ^2.0.23
   pinia-plugin-persistedstate: ^2.3.0
@@ -87,6 +88,7 @@ devDependencies:
   eslint-plugin-vue: 9.6.0_eslint@8.25.0
   husky: 8.0.1
   lint-staged: 13.0.3
+  mockjs: 1.1.0
   sass: 1.55.0
   terser: 5.16.1
   typescript: 4.8.4
@@ -3080,6 +3082,13 @@ packages:
       pathe: 0.3.9
       pkg-types: 0.3.5
       ufo: 0.8.5
+    dev: true
+
+  /mockjs/1.1.0:
+    resolution: {integrity: sha512-eQsKcWzIaZzEZ07NuEyO4Nw65g0hdWAyurVol1IPl1gahRwY+svqzfgfey8U8dahLwG44d6/RwEzuK52rSa/JQ==}
+    hasBin: true
+    dependencies:
+      commander: 9.4.0
     dev: true
 
   /mrmime/1.0.1:

--- a/src/api/_system/user.ts
+++ b/src/api/_system/user.ts
@@ -14,3 +14,12 @@ export const getAccountInfo = () => {
     url: Api.ACCOUNT_INFO
   })
 }
+
+export const getUserList = () => {
+  return useFetch.POST<{
+    list: UserInfoModel[]
+  }>({
+    url: '/mock' + Api.USER_LIST,
+    withToken: false
+  })
+}

--- a/src/views/admin/_sys/user/index.vue
+++ b/src/views/admin/_sys/user/index.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts" name="User">
   import SearchModel from '@/components/SearchModel'
   import { SearchItemConfig, useComponent } from '@/components/SearchModel'
-
+  import { getUserList } from '@/api/_system/user'
+  import { UserInfoModel } from '@/api/_system/model/userModel'
   const router = useRouter()
   const { ElInput, ElSelect, ElRadioButton } = useComponent()
   const data = reactive({
@@ -21,16 +22,7 @@
     { component: ElRadioButton , label: '启用状态', field: 'enabled', options: [{ label: '是', value: '1' }, { label: '否', value: '0' }] }
   ]
 
-  const tableData = Array(10).fill(0).map((r, i) => ({
-    id: i+1,
-    username: 'ikun',
-    name: '坤坤',
-    gender: '男',
-    mobile: '18818186868',
-    roles: '用户',
-    deptName: '产品研发部',
-    posts: '前端'
-  }))
+  const tableData = ref<UserInfoModel[]>([])
 
   const pageData = reactive({
     current: 1,
@@ -44,6 +36,10 @@
   function handleReset() {
     console.log('reset...')
   }
+
+  getUserList().then(r => {
+    tableData.value = r.list
+  })
 </script>
 
 <template>

--- a/types/auto-imports.d.ts
+++ b/types/auto-imports.d.ts
@@ -2,7 +2,6 @@
 export {}
 declare global {
   const EffectScope: typeof import('vue')['EffectScope']
-  const ElNotification: typeof import('element-plus/es')['ElNotification']
   const computed: typeof import('vue')['computed']
   const createApp: typeof import('vue')['createApp']
   const customRef: typeof import('vue')['customRef']


### PR DESCRIPTION
* 基于 Vite DevServe 新增 Mock 插件
* 新增 Mock 路由表配置，位于 `/mock` 
* 更改用户管理页面，使用新增的示例 mock 数据作为展示
* 新增 mockjs 依赖