### PR TITLE
修复tag过多，点击菜单，不会自动向左跳动的问题；实现tag右键菜单刷新的功能；修改动态路由的引入问题，传参例子：

### DIFF
--- a/src/layouts/admin/content/index.vue
+++ b/src/layouts/admin/content/index.vue
@@ -1,18 +1,32 @@
 <script setup lang="ts" name="LayoutContent">
-  import { useSettingStore } from '@/store/modules/setting'
+import { useSettingStore } from '@/store/modules/setting'
+import { useMenuStore } from '@/store/modules/menu'
 
-  const { hasPageAnimate } = $(useSettingStore())
+const { hasPageAnimate } = $(useSettingStore())
+
+const route = useRoute()
+const ComponentKey = ref(route.path)
+
+watch(() => useMenuStore().refreshRoute, v => {
+  const { updateRefreshRoute } = useMenuStore()
+  if (v) {
+    console.log(ComponentKey.value)
+    if (ComponentKey.value == route.path) {
+      ComponentKey.value = route.path + 1
+    } else {
+      ComponentKey.value = route.path
+    }
+    updateRefreshRoute(false)
+
+  }
+})
 </script>
 
 <template>
-  <el-main
-    p="3"
-    pb="0"
-    relative
-  >
+  <el-main p="3" pb="0" relative>
     <router-view v-slot="{ Component, route }">
       <transition :name="hasPageAnimate ? 'fade-slide' : ''">
-        <component :is="Component" :key="route.path" />
+        <component :is="Component" :key="ComponentKey" />
       </transition>
     </router-view>
   </el-main>

--- a/src/layouts/admin/tabs/index.vue
+++ b/src/layouts/admin/tabs/index.vue
@@ -1,78 +1,78 @@
 <script setup lang="ts" name="LayoutTabs">
-  import type { AppRouteConfig } from '@/router/types'
-  import { useAppStore } from '@/store/modules/app'
+import type { AppRouteConfig } from '@/router/types'
+import { useAppStore } from '@/store/modules/app'
+import { useMenuStore } from '@/store/modules/menu'
+import { ref } from 'vue'
 
-  let { visitedViews, addVisitedView, deleteVisitedView } = $(useAppStore())
-  const router = useRouter()
-  const route = useRoute()
-  const tabRef = ref<HTMLDivElement>()
+let { visitedViews, addVisitedView, deleteVisitedView } = $(useAppStore())
+const router = useRouter()
+const route = useRoute()
+const tabRef = ref<HTMLDivElement>()
 
-  watch(route, v => {
-    const { path, meta } = v
-    const success = addVisitedView({
-      path,
-      meta
-    })
-    if (success) {
-      scrollToActiveTag()
-    }
-  }, { immediate: true })
+watch(route, v => {
+  const { path, meta } = v
+  const success = addVisitedView({
+    path,
+    meta
+  })
+  scrollToActiveTag()
+}, { immediate: true })
 
-  function removeTag(v: AppRouteConfig) {
-    deleteVisitedView(v)
-    if (v.path === route.path) {
-      const lastTag = visitedViews[visitedViews.length - 1]
-      router.push(lastTag.path)
-    }
+function removeTag(v: AppRouteConfig) {
+  deleteVisitedView(v)
+  if (v.path === route.path) {
+    const lastTag = visitedViews[visitedViews.length - 1]
+    router.push(lastTag.path)
   }
+}
 
-  function removeOtherTag(v: AppRouteConfig) {
-    visitedViews = visitedViews.filter(view => view.path === v.path)
+function removeOtherTag(v: AppRouteConfig) {
+  visitedViews = visitedViews.filter(view => view.path === v.path)
+}
+
+function openMenu(v: AppRouteConfig) {
+  if (v.path !== route.path) router.push(v.path)
+}
+
+//刷新tag界面
+function refreshTag(v:AppRouteConfig){
+  const {updateRefreshRoute} = useMenuStore()
+  updateRefreshRoute(true)
+  // router.replace(v.path)
+}
+
+async function scrollToActiveTag() {
+  await nextTick()
+  // Todo: need handle -> active tag is existed & scroll to back
+  const domEle = document.querySelector(".active") as HTMLDivElement
+  let left = 0
+  if(domEle && domEle.parentElement){
+    left = domEle.parentElement.offsetLeft - (tabRef.value?tabRef.value.offsetLeft:0)
   }
-
-  function openMenu(v: AppRouteConfig) {
-    if (v.path !== route.path) router.push(v.path)
-  }
-
-  async function scrollToActiveTag() {
-    await nextTick()
-    // Todo: need handle -> active tag is existed & scroll to back
+  if (left < (tabRef.value?tabRef.value.scrollWidth:0)) {
+    tabRef.value?.scrollTo({ behavior: 'smooth', left: left - 20 })
+  } else {
     tabRef.value?.scrollTo({ behavior: 'smooth', left: tabRef.value.scrollWidth })
   }
+}
 
 </script>
 
 <template>
-  <div
-    ref="tabRef"
-    flex
-    items="center"
-    gap="2"
-    h="tab"
-    px-5
-    overflow-x="auto"
-  >
-    <el-dropdown
-      v-for="v in visitedViews"
-      :key="v.path"
-      trigger="contextmenu"
-    >
-      <el-tag
-        size="large"
-        :class="{ active: v.path === route.path }"
-        :type="v.path === route.path ? '' : 'info'"
-        :closable="v.path === route.path && visitedViews.length > 1"
-        @click="router.push(v.path)"
-        @close="removeTag(v)"
-        @contextmenu.prevent="openMenu(v)"
-      >
+  <div ref="tabRef" flex items="center" gap="2" h="tab" px-5 overflow-x="auto">
+    <el-dropdown v-for="v in visitedViews" :key="v.path" trigger="contextmenu">
+      <el-tag size="large" :class="{ active: v.path === route.path }" :type="v.path === route.path ? '' : 'info'"
+        :closable="v.path === route.path && visitedViews.length > 1" @click="router.push(v.path)" @close="removeTag(v)"
+        @contextmenu.prevent="openMenu(v)">
         {{ $t(v?.meta?.title!) }}
       </el-tag>
       <template #dropdown>
         <el-dropdown-menu>
-          <el-dropdown-item @click="router.replace(v.path)">{{ $t('tab.refresh') }}</el-dropdown-item>
-          <el-dropdown-item @click="removeTag(v)" :disabled="visitedViews.length === 1">{{ $t('tab.close') }}</el-dropdown-item>
-          <el-dropdown-item @click="removeOtherTag(v)" :disabled="visitedViews.length === 1">{{ $t('tab.closeOther') }}</el-dropdown-item>
+          <el-dropdown-item @click="refreshTag">{{ $t('tab.refresh') }}</el-dropdown-item>
+          <el-dropdown-item @click="removeTag(v)" :disabled="visitedViews.length === 1">{{ $t('tab.close')
+          }}</el-dropdown-item>
+          <el-dropdown-item @click="removeOtherTag(v)" :disabled="visitedViews.length === 1">{{ $t('tab.closeOther')
+          }}</el-dropdown-item>
         </el-dropdown-menu>
       </template>
     </el-dropdown>

--- a/src/store/modules/menu.ts
+++ b/src/store/modules/menu.ts
@@ -8,7 +8,8 @@ import { buildMenuApi } from '@/api/_system/menu'
 import { defineStore } from 'pinia'
 
 interface MenuState {
-  routes: AppRouteConfig[]
+  routes: AppRouteConfig[],
+  refreshRoute: boolean,
 }
 
 type RawRouteComponent = RouteComponent | (() => Promise<RouteComponent>)
@@ -21,7 +22,8 @@ function componentMap(path: string): RawRouteComponent {
       return AdminLayout
     default: {
       const joinPath = `admin/${path}`.replace(/\/\//, '/')
-      return pages[`../../views/${joinPath}.vue`]
+      const component = defineAsyncComponent(() => import(`/src/views/${joinPath}`/* @vite-ignore */))
+      return component
     }
   }
 }
@@ -41,12 +43,16 @@ function mapRoutes(serverRoutes: BuildMenuModel[]): AppRouteConfig[] {
 
 export const useMenuStore = defineStore('menu', {
   state: (): MenuState => ({
-    routes: []
+    routes: [],
+    refreshRoute: false,
   }),
   getters: {
     hasRoutes: state => state.routes.length > 0
   },
   actions: {
+    async updateRefreshRoute(bool: boolean){
+      this.refreshRoute = bool
+    },
     async generateRoutes() {
       const serverRoutes = await buildMenuApi()
       try {


### PR DESCRIPTION
const RouteResult:BuildMenuModel[] = [
  {
    path: "/system",
    name: "system",
    component: 'Layout',
    meta: {
      title: "menu.system.root",
      icon: "ri:settings-4-fill",
    },
    children: [
      {
        path: "menu",
        name: "menu",
        component: '_system/menu/index.vue',
        meta: {
          title: "menu.system.menu",
        },
      },
    ]
  }